### PR TITLE
Set base URL to fix RSS feed

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -2,7 +2,7 @@ title: Is Uberspace online?
 buildFuture: true
 defaultContentLanguage: en
 languageCode: en
-baseURL: /
+baseURL: https://is.uberspace.online
 params:
   alwaysKeepBrandColor: false
   autoRefresh: true


### PR DESCRIPTION
The RSS feed was [invalid](https://validator.w3.org/feed/check.cgi?url=https%3A%2F%2Fis.uberspace.online%2Findex.xml) because it contained no absolute URLs. Configuring the base URL fixes this.

I just sent a support email about this to you guys before I learned that I can fix the issue myself. Sorry about that, you can ignore the email.